### PR TITLE
Simplify DisplayInfo; add TargetId; update Windows + CLI

### DIFF
--- a/src/DisplayControl.Abstractions/Exceptions/DisplayControlException.cs
+++ b/src/DisplayControl.Abstractions/Exceptions/DisplayControlException.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace DisplayControl.Abstractions
+{
+    /// <summary>
+    /// Application-specific exception for Display Control operations.
+    /// Use this type to signal domain errors rather than throwing generic exceptions.
+    /// </summary>
+    [Serializable]
+    public class DisplayControlException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DisplayControlException"/> class.
+        /// </summary>
+        public DisplayControlException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DisplayControlException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        public DisplayControlException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DisplayControlException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception.</param>
+        public DisplayControlException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DisplayControlException"/> class with serialized data.
+        /// </summary>
+        /// <param name="info">The serialization information object holding the serialized object data.</param>
+        /// <param name="context">The streaming context that contains contextual information about the source or destination.</param>
+        protected DisplayControlException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}
+

--- a/src/DisplayControl.Abstractions/Models/DisplayInfo.cs
+++ b/src/DisplayControl.Abstractions/Models/DisplayInfo.cs
@@ -7,11 +7,13 @@ namespace DisplayControl.Abstractions.Models
     /// <param name="IsActive">True if the display is currently active.</param>
     /// <param name="IsPrimary">True if the display is the primary (top-left at 0,0).</param>
     /// <param name="Active">Active details when the display is active; otherwise null.</param>
+    /// <param name="TargetId">Underlying Windows target identifier for this display.</param>
     public record DisplayInfo(
         string? FriendlyName,
         bool IsActive,
         bool IsPrimary,
-        ActiveDetails? Active
+        ActiveDetails? Active,
+        uint TargetId
     );
 
     /// <summary>

--- a/src/DisplayControl.Abstractions/Models/DisplayInfo.cs
+++ b/src/DisplayControl.Abstractions/Models/DisplayInfo.cs
@@ -1,7 +1,7 @@
 namespace DisplayControl.Abstractions.Models
 {
     /// <summary>
-    /// Immutable description of a display device and its current state.
+    /// Immutable description of a display device and its minimal state used by the CLI.
     /// </summary>
     /// <param name="FriendlyName">Friendly monitor name reported by the system, when available.</param>
     /// <param name="IsActive">True if the display is currently active.</param>
@@ -15,27 +15,15 @@ namespace DisplayControl.Abstractions.Models
     );
 
     /// <summary>
-    /// Details about an active display path including geometry, refresh rate, scaling and color.
+    /// Minimal details about an active display path: geometry, refresh rate, and orientation.
     /// </summary>
-    /// <param name="GdiName">GDI device name (e.g. \\ .\\DISPLAYx).</param>
+    /// <param name="GdiName">GDI device name (e.g., \\ .\\DISPLAYx).</param>
     /// <param name="PositionX">Desktop X position of the top-left corner.</param>
     /// <param name="PositionY">Desktop Y position of the top-left corner.</param>
     /// <param name="Width">Active pixel width.</param>
     /// <param name="Height">Active pixel height.</param>
-    /// <param name="RefreshHz">Reported refresh rate in Hz.</param>
-    /// <param name="Orientation">Orientation name (Identity/Rotate90/Rotate180/Rotate270).
-    /// </param>
-    /// <param name="Scaling">Scaling mode if available.</param>
-    /// <param name="TextScalePercent">Effective text scaling percentage when available.</param>
-    /// <param name="ActiveRefreshHz">Active refresh rate from DEVMODE when available.</param>
-    /// <param name="DesktopRefreshHz">Desktop refresh rate approximation from DisplayConfig.</param>
-    /// <param name="AdaptiveRefreshHz">Adaptive/variable refresh rate when known; 0.0 otherwise.
-    /// </param>
-    /// <param name="HdrSupported">True if HDR/advanced color is supported.</param>
-    /// <param name="HdrEnabled">True if HDR/advanced color is currently enabled.</param>
-    /// <param name="ColorEncoding">Color encoding (e.g., RGB, YCbCr).</param>
-    /// <param name="BitsPerColor">Bits per color channel when known.</param>
-    /// <param name="ColorSpace">Color space information when known.</param>
+    /// <param name="RefreshHz">Refresh rate in Hz.</param>
+    /// <param name="Orientation">Orientation (Identity/Rotate90/Rotate180/Rotate270) when known.</param>
     public record ActiveDetails(
         string? GdiName,
         int PositionX,
@@ -43,17 +31,7 @@ namespace DisplayControl.Abstractions.Models
         uint Width,
         uint Height,
         double RefreshHz,
-        string? Orientation,
-        string? Scaling,
-        int? TextScalePercent,
-        double ActiveRefreshHz,
-        double DesktopRefreshHz,
-        double AdaptiveRefreshHz,
-        bool? HdrSupported,
-        bool? HdrEnabled,
-        string? ColorEncoding,
-        int? BitsPerColor,
-        string? ColorSpace
+        string? Orientation
     );
 }
 

--- a/src/DisplayControl.Cli/Program.cs
+++ b/src/DisplayControl.Cli/Program.cs
@@ -25,7 +25,7 @@ namespace DisplayControl.Cli
             {
                 return PrintHelp();
             }
-            
+
             try
             {
                 switch (args[0].ToLowerInvariant())

--- a/src/DisplayControl.Cli/Program.cs
+++ b/src/DisplayControl.Cli/Program.cs
@@ -91,13 +91,6 @@ static class Cli
                 if (details)
                 {
                     Console.WriteLine($"    Orientation: {a.Orientation ?? "-"}");
-                    Console.WriteLine($"    ScalingMode: {a.Scaling ?? "-"}");
-                    Console.WriteLine($"    TextScale: {(a.TextScalePercent.HasValue ? a.TextScalePercent + "%" : "-")}");
-                    Console.WriteLine($"    ActiveHz: {(a.ActiveRefreshHz > 0 ? a.ActiveRefreshHz.ToString("F1") : "-")}");
-                    Console.WriteLine($"    DesktopHz: {(a.DesktopRefreshHz > 0 ? a.DesktopRefreshHz.ToString("F1") : "-")}");
-                    Console.WriteLine($"    AdaptiveHz: {(a.AdaptiveRefreshHz > 0 ? a.AdaptiveRefreshHz.ToString("F1") : "-")}");
-                    Console.WriteLine($"    HDR: {(a.HdrSupported == true ? (a.HdrEnabled == true ? "Enabled" : "Supported") : "No")}");
-                    Console.WriteLine($"    Color: {(a.ColorEncoding ?? "-")}, {(a.BitsPerColor?.ToString() ?? "-")} bpc");
                 }
             }
             else

--- a/src/DisplayControl.Cli/Program.cs
+++ b/src/DisplayControl.Cli/Program.cs
@@ -8,202 +8,187 @@ using DisplayControl.Abstractions.Models;
 using DisplayControl.Windows.Services;
 using System.Runtime.InteropServices;
 
-/// <summary>
-/// Console entry point for display control operations.
-/// </summary>
-static class Cli
+namespace DisplayControl.Cli
 {
     /// <summary>
-    /// Entry point. Parses CLI arguments and invokes display operations.
+    /// Console entry point for display control operations.
     /// </summary>
-    static int Main(string[] args)
+    static class Program
     {
-        TryEnablePerMonitorDpiAwareness();
-        IDisplayConfigurator dc = new WindowsDisplayConfigurator();
-        if (args.Length == 0)
+        /// <summary>
+        /// Entry point. Parses CLI arguments and invokes display operations.
+        /// </summary>
+        static int Main(string[] args)
         {
-            return PrintHelp();
-        }
-
-        try
-        {
-            switch (args[0].ToLowerInvariant())
+            IDisplayConfigurator dc = new WindowsDisplayConfigurator();
+            if (args.Length == 0)
             {
-                case "list":
-                    return DoList(dc, args.Skip(1).ToArray());
-                case "enable":
-                    return RequireArg(args, 1, "enable <friendly>", out var name) ? DoEnable(dc, name!) : 2;
-                case "disable":
-                    return RequireArg(args, 1, "disable <\\.\\DISPLAYx|friendly>", out var dname) ? DoDisable(dc, dname!) : 2;
-                case "setprimary":
-                    return RequireArg(args, 1, "setprimary <\\.\\DISPLAYx|friendly>", out var spname) ? DoSetPrimary(dc, spname!) : 2;
-                case "profile":
-                    return RequireArg(args, 1, "profile <name>", out var pname) ? DoProfile(dc, pname!) : 2;
-                case "saveprofile":
-                    return DoSaveProfile(dc, args.Length > 1 ? args[1] : null);
-                default:
-                    Console.Error.WriteLine("Unrecognized command.");
-                    return PrintHelp();
+                return PrintHelp();
             }
-        }
-        catch (Exception ex)
-        {
-            Console.Error.WriteLine($"Error: {ex.Message}");
-            return 1;
-        }
-    }
-
-    /// <summary>
-    /// Attempts to enable Per-Monitor DPI awareness to improve display queries.
-    /// </summary>
-    static void TryEnablePerMonitorDpiAwareness()
-    {
-        try
-        {
-            // Try Per-Monitor V2 (Windows 10+)
-            if (!SetProcessDpiAwarenessContext(new IntPtr(-4))) // DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
+            
+            try
             {
-                // Fallback to Per-Monitor V1
-                SetProcessDpiAwareness(2); // PROCESS_PER_MONITOR_DPI_AWARE
-            }
-        }
-        catch { /* ignore */ }
-    }
-
-    [DllImport("user32.dll")]
-    static extern bool SetProcessDpiAwarenessContext(IntPtr value);
-
-    [DllImport("Shcore.dll")]
-    static extern int SetProcessDpiAwareness(int value);
-
-    /// <summary>
-    /// Lists displays with optional details flag.
-    /// </summary>
-    static int DoList(IDisplayConfigurator dc, string[] flags)
-    {
-        bool details = flags.Any(f => string.Equals(f, "--details", StringComparison.OrdinalIgnoreCase) || string.Equals(f, "-d", StringComparison.OrdinalIgnoreCase) || string.Equals(f, "-v", StringComparison.OrdinalIgnoreCase));
-        var list = dc.List();
-        foreach (var d in list)
-        {
-            if (d.IsActive && d.Active is var a && a != null)
-            {
-                Console.WriteLine($"- {d.FriendlyName ?? "<unnamed>"} | ACTIVE | {a.GdiName} | Pos {a.PositionX},{a.PositionY} | {a.Width}x{a.Height} | {a.RefreshHz:F1} Hz{(d.IsPrimary ? " | PRIMARY" : string.Empty)}");
-                if (details)
+                switch (args[0].ToLowerInvariant())
                 {
-                    Console.WriteLine($"    Orientation: {a.Orientation ?? "-"}");
+                    case "list":
+                        return DoList(dc, true);
+                    case "enable":
+                        return RequireArg(args, 1, "enable <friendly>", out var name) ? DoEnable(dc, name!) : 2;
+                    case "disable":
+                        return RequireArg(args, 1, "disable <\\.\\DISPLAYx|friendly>", out var dname) ? DoDisable(dc, dname!) : 2;
+                    case "setprimary":
+                        return RequireArg(args, 1, "setprimary <\\.\\DISPLAYx|friendly>", out var spname) ? DoSetPrimary(dc, spname!) : 2;
+                    case "profile":
+                        return RequireArg(args, 1, "profile <name>", out var pname) ? DoProfile(dc, pname!) : 2;
+                    case "saveprofile":
+                        return DoSaveProfile(dc, args.Length > 1 ? args[1] : null);
+                    default:
+                        Console.Error.WriteLine("Unrecognized command.");
+                        return PrintHelp();
                 }
             }
-            else
+            catch (Exception ex)
             {
-                Console.WriteLine($"- {d.FriendlyName ?? "<unnamed>"} | INACTIVE");
+                Console.Error.WriteLine($"Error: {ex.Message}");
+                return 1;
             }
         }
-        return 0;
-    }
 
-    /// <summary>
-    /// Enables a monitor by friendly name.
-    /// </summary>
-    static int DoEnable(IDisplayConfigurator dc, string name)
-    {
-        var r = dc.EnableMonitor(name);
-        Console.WriteLine(r.Success ? "OK" : $"FAIL: {r.Message}");
-        return r.Success ? 0 : 1;
-    }
-
-    /// <summary>
-    /// Disables a monitor by GDI device name or friendly name.
-    /// </summary>
-    static int DoDisable(IDisplayConfigurator dc, string name)
-    {
-        var r = dc.DisableMonitor(name);
-        Console.WriteLine(r.Success ? "OK" : $"FAIL: {r.Message}");
-        return r.Success ? 0 : 1;
-    }
-
-    /// <summary>
-    /// Sets the primary monitor.
-    /// </summary>
-    static int DoSetPrimary(IDisplayConfigurator dc, string name)
-    {
-        var r = dc.SetPrimary(name);
-        Console.WriteLine(r.Success ? "OK" : $"FAIL: {r.Message}");
-        return r.Success ? 0 : 1;
-    }
-
-    /// <summary>
-    /// Applies a profile by name from JSON or a built-in fallback.
-    /// </summary>
-    static int DoProfile(IDisplayConfigurator dc, string profileName)
-    {
-        var (found, profile) = TryLoadProfile(profileName);
-        if (found && profile != null)
+        /// <summary>
+        /// Lists displays with optional details flag.
+        /// </summary>
+        static int DoList(IDisplayConfigurator dc, bool details)
         {
-            var res = dc.SetMonitors(profile);
-            Console.WriteLine(res.Success ? $"Profile '{profileName}' applied." : $"FAIL: {res.Message}");
-            return res.Success ? 0 : 1;
+            var list = dc.List()
+                .OrderByDescending(d => d.IsPrimary)
+                .ThenByDescending(d => d.IsActive)
+                .ThenBy(d => d.FriendlyName ?? string.Empty)
+                .ToList();
+            foreach (var d in list)
+            {
+                if (d.IsActive && d.Active is var a && a != null)
+                {
+                    Console.WriteLine($"- {d.FriendlyName} | ACTIVE{(d.IsPrimary ? " | PRIMARY" : string.Empty)}");
+                    if (details)
+                    {
+                        Console.WriteLine($"    GdiName: {a.GdiName ?? "-"}");
+                        Console.WriteLine($"    Position: {a.PositionX},{a.PositionY}");
+                        Console.WriteLine($"    Resolution: {a.Width}x{a.Height}");
+                        Console.WriteLine($"    RefreshHz: {(a.RefreshHz > 0 ? a.RefreshHz.ToString("F1") : "-")}");
+                        Console.WriteLine($"    Orientation: {a.Orientation ?? "-"}");
+                    }
+                }
+                else
+                {
+                    Console.WriteLine($"- {d.FriendlyName} | INACTIVE");
+                }
+            }
+            return 0;
         }
-        return 0;
-    }
 
-    /// <summary>
-    /// Saves the current layout to a JSON profile.
-    /// </summary>
-    static int DoSaveProfile(IDisplayConfigurator dc, string? name)
-    {
-        var r = dc.SaveProfile(name);
-        Console.WriteLine(r.Success ? (r.Message ?? "Profile saved") : $"FAIL: {r.Message}");
-        return r.Success ? 0 : 1;
-    }
-
-    /// <summary>
-    /// Ensures an argument exists at the given index, otherwise prints usage.
-    /// </summary>
-    static bool RequireArg(string[] args, int index, string usage, out string? value)
-    {
-        if (args.Length <= index)
+        /// <summary>
+        /// Enables a monitor by friendly name.
+        /// </summary>
+        static int DoEnable(IDisplayConfigurator dc, string name)
         {
-            Console.Error.WriteLine("Usage: " + usage);
-            value = null;
-            return false;
+            var r = dc.EnableMonitor(name);
+            Console.WriteLine(r.Success ? "OK" : $"FAIL: {r.Message}");
+            return r.Success ? 0 : 1;
         }
-        value = args[index];
-        return true;
-    }
 
-    /// <summary>
-    /// Prints CLI usage.
-    /// </summary>
-    static int PrintHelp()
-    {
-        Console.WriteLine("Usage:");
-        Console.WriteLine("  displayctl list [--details|-d|-v]");
-        Console.WriteLine("  displayctl enable <friendly>");
-        Console.WriteLine("  displayctl disable <\\.\\DISPLAYx|friendly>");
-        Console.WriteLine("  displayctl setprimary <\\.\\DISPLAYx|friendly>");
-        Console.WriteLine("  displayctl profile <name>");
-        Console.WriteLine("  displayctl saveprofile [name]");
-        return 2;
-    }
-
-    /// <summary>
-    /// Attempts to load a JSON profile by name from the local profiles directory.
-    /// </summary>
-    static (bool found, DesiredProfile? profile) TryLoadProfile(string name)
-    {
-        try
+        /// <summary>
+        /// Disables a monitor by GDI device name or friendly name.
+        /// </summary>
+        static int DoDisable(IDisplayConfigurator dc, string name)
         {
-            string dir = Path.Combine(Environment.CurrentDirectory, "profiles");
-            string path = Path.Combine(dir, name + ".json");
-            if (!File.Exists(path)) return (false, null);
-            var json = File.ReadAllText(path);
-            var profile = JsonSerializer.Deserialize<DesiredProfile>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-            return (profile != null, profile);
+            var r = dc.DisableMonitor(name);
+            Console.WriteLine(r.Success ? "OK" : $"FAIL: {r.Message}");
+            return r.Success ? 0 : 1;
         }
-        catch
+
+        /// <summary>
+        /// Sets the primary monitor.
+        /// </summary>
+        static int DoSetPrimary(IDisplayConfigurator dc, string name)
         {
-            return (false, null);
+            var r = dc.SetPrimary(name);
+            Console.WriteLine(r.Success ? "OK" : $"FAIL: {r.Message}");
+            return r.Success ? 0 : 1;
+        }
+
+        /// <summary>
+        /// Applies a profile by name from JSON or a built-in fallback.
+        /// </summary>
+        static int DoProfile(IDisplayConfigurator dc, string profileName)
+        {
+            var (found, profile) = TryLoadProfile(profileName);
+            if (found && profile != null)
+            {
+                var res = dc.SetMonitors(profile);
+                Console.WriteLine(res.Success ? $"Profile '{profileName}' applied." : $"FAIL: {res.Message}");
+                return res.Success ? 0 : 1;
+            }
+            return 0;
+        }
+
+        /// <summary>
+        /// Saves the current layout to a JSON profile.
+        /// </summary>
+        static int DoSaveProfile(IDisplayConfigurator dc, string? name)
+        {
+            var r = dc.SaveProfile(name);
+            Console.WriteLine(r.Success ? (r.Message ?? "Profile saved") : $"FAIL: {r.Message}");
+            return r.Success ? 0 : 1;
+        }
+
+        /// <summary>
+        /// Ensures an argument exists at the given index, otherwise prints usage.
+        /// </summary>
+        static bool RequireArg(string[] args, int index, string usage, out string? value)
+        {
+            if (args.Length <= index)
+            {
+                Console.Error.WriteLine("Usage: " + usage);
+                value = null;
+                return false;
+            }
+            value = args[index];
+            return true;
+        }
+
+        /// <summary>
+        /// Prints CLI usage.
+        /// </summary>
+        static int PrintHelp()
+        {
+            Console.WriteLine("Usage:");
+            Console.WriteLine("  displayctl list [--details|-d|-v]");
+            Console.WriteLine("  displayctl enable <friendly>");
+            Console.WriteLine("  displayctl disable <\\.\\DISPLAYx|friendly>");
+            Console.WriteLine("  displayctl setprimary <\\.\\DISPLAYx|friendly>");
+            Console.WriteLine("  displayctl profile <name>");
+            Console.WriteLine("  displayctl saveprofile [name]");
+            return 2;
+        }
+
+        /// <summary>
+        /// Attempts to load a JSON profile by name from the local profiles directory.
+        /// </summary>
+        static (bool found, DesiredProfile? profile) TryLoadProfile(string name)
+        {
+            try
+            {
+                string dir = Path.Combine(Environment.CurrentDirectory, "profiles");
+                string path = Path.Combine(dir, name + ".json");
+                if (!File.Exists(path)) return (false, null);
+                var json = File.ReadAllText(path);
+                var profile = JsonSerializer.Deserialize<DesiredProfile>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                return (profile != null, profile);
+            }
+            catch
+            {
+                return (false, null);
+            }
         }
     }
 }
-


### PR DESCRIPTION
﻿## Summary
Simplify `DisplayInfo` to essential fields and add `TargetId`. Update Windows configurator to populate `TargetId` and map the streamlined model; update CLI output/usages accordingly. Introduces `DisplayControlException` for clearer domain-level errors.

## Related Issues
N/A

## Scope
- [x] [cli]
- [x] [windows]
- [x] [abstractions]
- [ ] [docs]

## Details
- Simplified `DisplayInfo`/`ActiveDetails` to a minimal, stable surface.
- Added `TargetId` to `DisplayInfo` and populated from Windows target data.
- Refactored `WindowsDisplayConfigurator` to set `TargetId` and align with the reduced model.
- Added `DisplayControlException` with XML summaries.
- Adjusted CLI to use the new shape and keep list output useful.

## How to Test
1) `dotnet restore`
2) `dotnet build`
3) Run: `dotnet run --project src/DisplayControl.Cli -- list`
4) Verify displays enumerate correctly and primary/active flags look right.

## Sample CLI Output (if applicable)
```text
$ dotnet run --project src/DisplayControl.Cli -- list
- DELL G2723HN | ACTIVE | PRIMARY
    GdiName: \\ \\.\\DISPLAY2
    Position: 0,0
    Resolution: 1920x1080
    RefreshHz: 120.0
    Orientation: Identity
-  | ACTIVE
    GdiName: \\ \\.\\DISPLAY1
    Position: 1920,0
    Resolution: 1920x1080
    RefreshHz: 60.0
    Orientation: Identity
```

## Screenshots (optional)
N/A

## Breaking Changes
- [x] Yes (describe migration/impact below)
- [ ] No

The `DisplayInfo` and `ActiveDetails` shapes were reduced; any external usages should update to the new minimal properties and, if needed, prefer `TargetId` for stable targeting.

## Checklist
- [x] Targets correct base branch (develop for features; master only for release/* or hotfix/*)
- [x] English-only names, strings, and documentation
- [x] `dotnet build` succeeds
- [x] `dotnet format` produces no changes
- [ ] `dotnet test` passes (if tests exist/affected)
- [ ] Docs updated as needed ([README](../README.md), [ROADMAP](../ROADMAP.md), [AGENTS](../AGENTS.md))
- [ ] For Windows interop: added XML summaries + link to Microsoft Docs
- [ ] CLI help/output updated if behavior or options changed
- [x] No commented-out code; minimal, meaningful inline comments only
- [x] Considered permissions/safety (display reconfiguration can blank screens)
