### PR TITLE
Rollback + confirmation; profile path under ~/.ewDisplayControl

### DIFF
--- a/src/DisplayControl.Cli/Program.cs
+++ b/src/DisplayControl.Cli/Program.cs
@@ -125,8 +125,13 @@ namespace DisplayControl.Cli
             if (found && profile != null)
             {
                 var res = dc.SetMonitors(profile);
-                Console.WriteLine(res.Success ? $"Profile '{profileName}' applied." : $"FAIL: {res.Message}");
-                return res.Success ? 0 : 1;
+                if (res.Success)
+                {
+                    Console.WriteLine(res.Message ?? $"Profile '{profileName}' applied.");
+                    return 0;
+                }
+                Console.WriteLine($"FAIL: {res.Message}");
+                return 1;
             }
             return 0;
         }

--- a/src/DisplayControl.Cli/Program.cs
+++ b/src/DisplayControl.Cli/Program.cs
@@ -172,13 +172,14 @@ namespace DisplayControl.Cli
         }
 
         /// <summary>
-        /// Attempts to load a JSON profile by name from the local profiles directory.
+        /// Attempts to load a JSON profile by name from the user's .ewDisplayControl directory.
         /// </summary>
         static (bool found, DesiredProfile? profile) TryLoadProfile(string name)
         {
             try
             {
-                string dir = Path.Combine(Environment.CurrentDirectory, "profiles");
+                string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                string dir = Path.Combine(home, ".ewDisplayControl");
                 string path = Path.Combine(dir, name + ".json");
                 if (!File.Exists(path)) return (false, null);
                 var json = File.ReadAllText(path);

--- a/src/DisplayControl.Windows/Interop/User32/User32.Dialogs.cs
+++ b/src/DisplayControl.Windows/Interop/User32/User32.Dialogs.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace DisplayControl.Windows.Interop.User32
+{
+    /// <summary>
+    /// User32 dialog helpers for MessageBox and basic window operations.
+    /// </summary>
+    /// <remarks>
+    /// MessageBox: https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-messageboxw
+    /// FindWindow: https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-findwindoww
+    /// PostMessage: https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-postmessagew
+    /// SetForegroundWindow: https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setforegroundwindow
+    /// </remarks>
+    internal static class User32Dialogs
+    {
+        public const int IDYES = 6;
+        public const int IDNO = 7;
+
+        public const uint MB_OK = 0x00000000;
+        public const uint MB_YESNO = 0x00000004;
+        public const uint MB_ICONQUESTION = 0x00000020;
+        public const uint MB_SETFOREGROUND = 0x00010000;
+        public const uint MB_TOPMOST = 0x00040000;
+
+        private const uint WM_CLOSE = 0x0010;
+
+        /// <summary>
+        /// Shows a top-most MessageBox with the specified flags enforced.
+        /// </summary>
+        public static int MessageBoxTopMost(IntPtr hWnd, string text, string caption, uint type)
+        {
+            // Ensure top-most flag is present.
+            type |= MB_TOPMOST;
+            return MessageBoxW(hWnd, text, caption, type);
+        }
+
+        /// <summary>
+        /// Attempts to find a top-level window by its caption (title).
+        /// </summary>
+        public static IntPtr FindWindowByCaption(string caption)
+        {
+            return FindWindowW(null, caption);
+        }
+
+        /// <summary>
+        /// Posts WM_CLOSE to a window handle.
+        /// </summary>
+        public static void PostClose(IntPtr hWnd)
+        {
+            PostMessageW(hWnd, WM_CLOSE, IntPtr.Zero, IntPtr.Zero);
+        }
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern int MessageBoxW(IntPtr hWnd, string lpText, string lpCaption, uint uType);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern IntPtr FindWindowW(string? lpClassName, string? lpWindowName);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool PostMessageW(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool SetForegroundWindow(IntPtr hWnd);
+    }
+}
+

--- a/src/DisplayControl.Windows/Services/WindowsDisplayConfigurator.cs
+++ b/src/DisplayControl.Windows/Services/WindowsDisplayConfigurator.cs
@@ -592,11 +592,15 @@ namespace DisplayControl.Windows.Services
             if (!apply.Success)
             {
                 var rb = ApplyFullProfile(snapshot);
-                if (!rb.Success)
+                if (rb.Success)
+                {
+                    return Result.Fail("Failed to apply profile; previous layout restored");
+                }
+                else
                 {
                     FallbackEnsurePrimary(snapshot.PrimaryName);
+                    return Result.Fail("Failed to apply profile; applied safety fallback (could not restore full layout)");
                 }
-                return Result.Fail(apply.Message ?? "Failed to apply profile");
             }
 
             // Ask for confirmation with a top-most dialog; revert on timeout or cancel.

--- a/src/DisplayControl.Windows/Services/WindowsDisplayConfigurator.cs
+++ b/src/DisplayControl.Windows/Services/WindowsDisplayConfigurator.cs
@@ -816,7 +816,7 @@ namespace DisplayControl.Windows.Services
             return null;
         }
 
-        /// <summary>Saves the current layout as a profile JSON file under the local profiles directory.</summary>
+        /// <summary>Saves the current layout as a profile JSON file under the user's .ewDisplayControl directory.</summary>
         public Result SaveProfile(string? name = null)
         {
             var current = List();
@@ -845,7 +845,8 @@ namespace DisplayControl.Windows.Services
 
             try
             {
-                string dir = Path.Combine(Environment.CurrentDirectory, "profiles");
+                string userDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                string dir = Path.Combine(userDir, ".ewDisplayControl");
                 Directory.CreateDirectory(dir);
                 string path = Path.Combine(dir, (name ?? "current") + ".json");
                 var json = JsonSerializer.Serialize(profile, new JsonSerializerOptions { WriteIndented = true });


### PR DESCRIPTION
﻿## Summary
Add in-memory rollback when applying profiles and a top-most confirmation dialog (15s timeout). Store/load profiles from user home `~/.ewDisplayControl`.

## Related Issues
N/A

## Scope
- [x] [windows]
- [x] [cli]
- [ ] [abstractions]
- [ ] [docs]

## Details
- Snapshot current layout before applying a profile; on failure, revert to snapshot; if revert fails, ensure previous primary is enabled and set as primary.
- Prompt to keep changes (Yes/No) with timeout; revert automatically if no.
- Save current layout and load profiles from `~/.ewDisplayControl`.
- Clear user-facing messages for apply failure vs safety fallback ("could not restore full layout").

## How to Test
1) `dotnet build`
2) Apply a profile: `displayctl profile <name>`
3) Choose No on the confirmation dialog and observe revert
4) (Optional) Unplug a monitor to force safety fallback and observe message

## Sample CLI Output
```text
Changes reverted
```

## Breaking Changes
- [ ] Yes
- [x] No

## Checklist
- [x] Targets correct base branch (develop for features)
- [x] English-only names, strings, and documentation
- [x] `dotnet build` succeeds
- [x] `dotnet format` produces no changes
- [ ] Docs updated as needed
