### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: "Bug report"
+about: "Report a problem with DisplayControl (CLI or Windows services)"
+title: "[Bug]: "
+labels: [bug]
+assignees: []
+---
+
+## Description
+A clear, concise description of the bug.
+
+## Reproduction Steps
+- Command(s) run (include full output):
+  - Example: `dotnet run --project src/DisplayControl.Cli -- list`
+- What you expected to happen
+- What actually happened
+
+## Display Setup
+- Number of monitors and arrangement (primary, extended, mirroring)
+- Display identifiers (e.g., `\\.\DISPLAY1`, `\\.\DISPLAY2`) and friendly names from `displayctl list`
+- GPU/adapter(s) and connection types (HDMI/DP/USB-C)
+- Any profiles used (e.g., `work`, `tv`, `all`)
+
+## Environment
+- OS: Windows 10/11 (build/version)
+- .NET SDK: output of `dotnet --info`
+- Architecture: x64
+- Terminal: Windows Terminal/PowerShell/CMD
+- Project commit/ref (if building locally):
+
+## Logs / Screenshots
+- Relevant console output
+- Exceptions/stack traces if available
+
+## Additional Context
+- Were you screen sharing or on battery power?
+- Recent changes before the issue appeared?
+
+---
+Safety note: Display reconfiguration can briefly blank screens. Avoid running during critical sessions or screen sharing.
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: "Feature request"
+about: "Suggest an enhancement for DisplayControl"
+title: "[Feature]: "
+labels: [enhancement]
+assignees: []
+---
+
+## Problem
+What problem does this feature solve? Why is it valuable?
+
+## Proposed Solution
+- Describe the behavior and scope
+- CLI UX (example commands/flags), e.g.:
+  - `dotnet run --project src/DisplayControl.Cli -- profile gaming`
+  - `displayctl enable "Dell U2720Q"`
+
+## Alternatives Considered
+Other approaches you considered and trade-offs.
+
+## Implementation Hints (optional)
+- Impacted modules: `DisplayControl.Abstractions`, `DisplayControl.Windows`, `DisplayControl.Cli`
+- Relevant Windows APIs (if known) with links
+- Data models or interop changes needed
+
+## Tests
+- Suggested test cases and acceptance criteria
+
+## Additional Context
+Screenshots, references, or related issues.
+

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,28 @@
+---
+name: "Task / Chore"
+about: "Track internal maintenance, refactors, or chores"
+title: "[Task]: "
+labels: [chore]
+assignees: []
+---
+
+## Scope
+Short summary of the task and motivation.
+
+## Acceptance Criteria
+- [ ] Criteria 1
+- [ ] Criteria 2
+
+## Impacted Areas
+- Modules: `DisplayControl.Abstractions`, `DisplayControl.Windows`, `DisplayControl.Cli`
+- Docs/Configs: README, CHANGELOG, build/publish scripts
+
+## Testing
+How will we verify this task? Unit tests, manual checks, or CI.
+
+## Out of Scope
+Explicitly list what is not included.
+
+## Notes
+Any additional context or follow-ups.
+


### PR DESCRIPTION
## Summary
Adds basic GitHub issue templates and disables blank issues. No runtime code changes.

## Related Issues
N/A

## Scope
- [x] [docs]
- [ ] [cli]
- [ ] [windows]
- [ ] [abstractions]

## Details
Adds the following files:
- .github/ISSUE_TEMPLATE/bug_report.md
- .github/ISSUE_TEMPLATE/feature_request.md
- .github/ISSUE_TEMPLATE/task.md
- .github/ISSUE_TEMPLATE/config.yml (disables blank issues)

## How to Test
- Open "New issue" in GitHub UI and verify templates appear.
- Confirm blank issues are disabled.

## Sample CLI Output (if applicable)
N/A

## Screenshots (optional)
N/A

## Breaking Changes
- [ ] Yes
- [x] No

## Checklist
- [x] Targets correct base branch (develop for features; master only for release/* or hotfix/*)
- [x] English-only names, strings, and documentation
- [x] `dotnet build` succeeds (no code changes)
- [x] `dotnet format` produces no changes (no code changes)
- [x] Docs updated as needed
- [x] CLI help/output unaffected
- [x] Considered permissions/safety (display reconfiguration can blank screens)
