### PR TITLE
[gui] Scaffold WinUI 3 app and add to solution

### DIFF
--- a/ConsoleApp.sln
+++ b/ConsoleApp.sln
@@ -1,3 +1,4 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
@@ -10,24 +11,66 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DisplayControl.Cli", "src\D
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DisplayControl.Windows", "src\DisplayControl.Windows\DisplayControl.Windows.csproj", "{E59AE158-D5B8-84BD-1C93-4849185F5403}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DisplayControl.Gui", "src\DisplayControl.Gui\DisplayControl.Gui.csproj", "{21F2A969-10F2-4D2A-AB01-6CD57BEBC14E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A1D35444-2CE6-7016-E562-F242E908EE8D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A1D35444-2CE6-7016-E562-F242E908EE8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1D35444-2CE6-7016-E562-F242E908EE8D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A1D35444-2CE6-7016-E562-F242E908EE8D}.Debug|x64.Build.0 = Debug|Any CPU
+		{A1D35444-2CE6-7016-E562-F242E908EE8D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A1D35444-2CE6-7016-E562-F242E908EE8D}.Debug|x86.Build.0 = Debug|Any CPU
 		{A1D35444-2CE6-7016-E562-F242E908EE8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1D35444-2CE6-7016-E562-F242E908EE8D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1D35444-2CE6-7016-E562-F242E908EE8D}.Release|x64.ActiveCfg = Release|Any CPU
+		{A1D35444-2CE6-7016-E562-F242E908EE8D}.Release|x64.Build.0 = Release|Any CPU
+		{A1D35444-2CE6-7016-E562-F242E908EE8D}.Release|x86.ActiveCfg = Release|Any CPU
+		{A1D35444-2CE6-7016-E562-F242E908EE8D}.Release|x86.Build.0 = Release|Any CPU
 		{16AF481A-6B0E-37FB-6065-0AEAE99F8166}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{16AF481A-6B0E-37FB-6065-0AEAE99F8166}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{16AF481A-6B0E-37FB-6065-0AEAE99F8166}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{16AF481A-6B0E-37FB-6065-0AEAE99F8166}.Debug|x64.Build.0 = Debug|Any CPU
+		{16AF481A-6B0E-37FB-6065-0AEAE99F8166}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{16AF481A-6B0E-37FB-6065-0AEAE99F8166}.Debug|x86.Build.0 = Debug|Any CPU
 		{16AF481A-6B0E-37FB-6065-0AEAE99F8166}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{16AF481A-6B0E-37FB-6065-0AEAE99F8166}.Release|Any CPU.Build.0 = Release|Any CPU
+		{16AF481A-6B0E-37FB-6065-0AEAE99F8166}.Release|x64.ActiveCfg = Release|Any CPU
+		{16AF481A-6B0E-37FB-6065-0AEAE99F8166}.Release|x64.Build.0 = Release|Any CPU
+		{16AF481A-6B0E-37FB-6065-0AEAE99F8166}.Release|x86.ActiveCfg = Release|Any CPU
+		{16AF481A-6B0E-37FB-6065-0AEAE99F8166}.Release|x86.Build.0 = Release|Any CPU
 		{E59AE158-D5B8-84BD-1C93-4849185F5403}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E59AE158-D5B8-84BD-1C93-4849185F5403}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E59AE158-D5B8-84BD-1C93-4849185F5403}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E59AE158-D5B8-84BD-1C93-4849185F5403}.Debug|x64.Build.0 = Debug|Any CPU
+		{E59AE158-D5B8-84BD-1C93-4849185F5403}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E59AE158-D5B8-84BD-1C93-4849185F5403}.Debug|x86.Build.0 = Debug|Any CPU
 		{E59AE158-D5B8-84BD-1C93-4849185F5403}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E59AE158-D5B8-84BD-1C93-4849185F5403}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E59AE158-D5B8-84BD-1C93-4849185F5403}.Release|x64.ActiveCfg = Release|Any CPU
+		{E59AE158-D5B8-84BD-1C93-4849185F5403}.Release|x64.Build.0 = Release|Any CPU
+		{E59AE158-D5B8-84BD-1C93-4849185F5403}.Release|x86.ActiveCfg = Release|Any CPU
+		{E59AE158-D5B8-84BD-1C93-4849185F5403}.Release|x86.Build.0 = Release|Any CPU
+		{21F2A969-10F2-4D2A-AB01-6CD57BEBC14E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{21F2A969-10F2-4D2A-AB01-6CD57BEBC14E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{21F2A969-10F2-4D2A-AB01-6CD57BEBC14E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{21F2A969-10F2-4D2A-AB01-6CD57BEBC14E}.Debug|x64.Build.0 = Debug|Any CPU
+		{21F2A969-10F2-4D2A-AB01-6CD57BEBC14E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{21F2A969-10F2-4D2A-AB01-6CD57BEBC14E}.Debug|x86.Build.0 = Debug|Any CPU
+		{21F2A969-10F2-4D2A-AB01-6CD57BEBC14E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{21F2A969-10F2-4D2A-AB01-6CD57BEBC14E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{21F2A969-10F2-4D2A-AB01-6CD57BEBC14E}.Release|x64.ActiveCfg = Release|Any CPU
+		{21F2A969-10F2-4D2A-AB01-6CD57BEBC14E}.Release|x64.Build.0 = Release|Any CPU
+		{21F2A969-10F2-4D2A-AB01-6CD57BEBC14E}.Release|x86.ActiveCfg = Release|Any CPU
+		{21F2A969-10F2-4D2A-AB01-6CD57BEBC14E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -36,6 +79,7 @@ Global
 		{A1D35444-2CE6-7016-E562-F242E908EE8D} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{16AF481A-6B0E-37FB-6065-0AEAE99F8166} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{E59AE158-D5B8-84BD-1C93-4849185F5403} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{21F2A969-10F2-4D2A-AB01-6CD57BEBC14E} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {06800007-613F-49C4-A248-0DB878D2ECFB}

--- a/README.md
+++ b/README.md
@@ -101,3 +101,12 @@ Notes:
 ## License
 - Source code: MIT License with Commons Clause. See [LICENSE](LICENSE).
 - Microsoft Store binary: governed by [EULA.txt](EULA.txt) (no redistribution, no sublicensing).
+
+## GUI (WinUI 3)
+A minimal WinUI 3 desktop app has been added under `src/DisplayControl.Gui`.
+
+- Target: `.NET 8` with `Microsoft.WindowsAppSDK` (WinUI 3)
+- Run (from solution root): open in Visual Studio 2022 (Windows) or use `dotnet build` (building requires Windows SDK + Windows App SDK tooling)
+- References: `DisplayControl.Abstractions`, `DisplayControl.Windows`
+
+This is a placeholder shell window to enable subsequent GUI work for 0.6.0.

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "9.0.304",
+    "rollForward": "latestFeature"
+  }
+}

--- a/src/DisplayControl.Gui/App.xaml
+++ b/src/DisplayControl.Gui/App.xaml
@@ -1,0 +1,8 @@
+<Application
+    x:Class="DisplayControl.Gui.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Application.Resources>
+    </Application.Resources>
+</Application>
+

--- a/src/DisplayControl.Gui/App.xaml.cs
+++ b/src/DisplayControl.Gui/App.xaml.cs
@@ -1,0 +1,23 @@
+using Microsoft.UI.Xaml;
+
+namespace DisplayControl.Gui
+{
+    /// <summary>
+    /// Application entry point for the DisplayControl WinUI 3 desktop app.
+    /// </summary>
+    public partial class App : Application
+    {
+        private Window? _window;
+
+        /// <summary>
+        /// Occurs when the application is launched by the end user.
+        /// </summary>
+        /// <param name="args">Launch arguments.</param>
+        protected override void OnLaunched(LaunchActivatedEventArgs args)
+        {
+            _window = new MainWindow();
+            _window.Activate();
+        }
+    }
+}
+

--- a/src/DisplayControl.Gui/DisplayControl.Gui.csproj
+++ b/src/DisplayControl.Gui/DisplayControl.Gui.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWinUI>true</UseWinUI>
+    <EnablePreviewMsixTooling>false</EnablePreviewMsixTooling>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Pick latest 1.x at restore time to ensure .NET 8 compatibility -->
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="[1.6.0,2.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DisplayControl.Abstractions\DisplayControl.Abstractions.csproj" />
+    <ProjectReference Include="..\DisplayControl.Windows\DisplayControl.Windows.csproj" />
+  </ItemGroup>
+
+</Project>
+

--- a/src/DisplayControl.Gui/DisplayControl.Gui.csproj
+++ b/src/DisplayControl.Gui/DisplayControl.Gui.csproj
@@ -1,17 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWinUI>true</UseWinUI>
     <EnablePreviewMsixTooling>false</EnablePreviewMsixTooling>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <!-- Allow building with newer .NET SDKs by explicitly setting the Windows SDK ref pack -->
+    <WindowsSdkPackageVersion>10.0.26100.38</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Pick latest 1.x at restore time to ensure .NET 8 compatibility -->
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="[1.6.0,2.0.0)" />
+    <!-- Pin to a stable 1.6 patch while we stabilize .NET 9 build -->
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240829007" />
+    <!-- Build tools for WinUI/MSIX tasks when VS packaging tools are not present -->
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,4 +24,3 @@
   </ItemGroup>
 
 </Project>
-

--- a/src/DisplayControl.Gui/MainWindow.xaml
+++ b/src/DisplayControl.Gui/MainWindow.xaml
@@ -1,0 +1,14 @@
+<Window
+    x:Class="DisplayControl.Gui.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="DisplayControl" Width="900" Height="600">
+    <Grid>
+        <StackPanel Spacing="12" Padding="16">
+            <TextBlock Text="DisplayControl GUI (0.6.0 scaffold)" FontSize="20"/>
+            <TextBlock Text="This is a placeholder shell window."
+                       Opacity="0.8"/>
+        </StackPanel>
+    </Grid>
+</Window>
+

--- a/src/DisplayControl.Gui/MainWindow.xaml
+++ b/src/DisplayControl.Gui/MainWindow.xaml
@@ -1,8 +1,7 @@
 <Window
     x:Class="DisplayControl.Gui.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    Title="DisplayControl" Width="900" Height="600">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Grid>
         <StackPanel Spacing="12" Padding="16">
             <TextBlock Text="DisplayControl GUI (0.6.0 scaffold)" FontSize="20"/>
@@ -11,4 +10,3 @@
         </StackPanel>
     </Grid>
 </Window>
-

--- a/src/DisplayControl.Gui/MainWindow.xaml.cs
+++ b/src/DisplayControl.Gui/MainWindow.xaml.cs
@@ -1,0 +1,20 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace DisplayControl.Gui
+{
+    /// <summary>
+    /// Main window for the DisplayControl GUI.
+    /// </summary>
+    public sealed partial class MainWindow : Window
+    {
+        /// <summary>
+        /// Creates the main application window.
+        /// </summary>
+        public MainWindow()
+        {
+            this.InitializeComponent();
+        }
+    }
+}
+

--- a/src/DisplayControl.Gui/app.manifest
+++ b/src/DisplayControl.Gui/app.manifest
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="DisplayControl.Gui.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>
+


### PR DESCRIPTION
Scaffold minimal WinUI 3 desktop app under src/DisplayControl.Gui and add to solution.\n\n- .NET 8, Windows App SDK (WinUI 3)\n- Adds App.xaml, MainWindow, and manifest\n- References DisplayControl.Abstractions and DisplayControl.Windows\n- README updated with short GUI section\n\nRefs #7